### PR TITLE
Fix test compilation error: Wrap NSError in SendableError

### DIFF
--- a/Sources/SwiftAI/Core/Types/GeneratedImage.swift
+++ b/Sources/SwiftAI/Core/Types/GeneratedImage.swift
@@ -92,7 +92,7 @@ public struct GeneratedImage: Sendable {
         do {
             try data.write(to: url, options: .atomic)
         } catch {
-            throw GeneratedImageError.saveFailed(underlying: error)
+            throw GeneratedImageError.saveFailed(underlying: SendableError(error))
         }
     }
 
@@ -110,7 +110,7 @@ public struct GeneratedImage: Sendable {
         do {
             try data.write(to: url, options: .atomic)
         } catch {
-            throw GeneratedImageError.saveFailed(underlying: error)
+            throw GeneratedImageError.saveFailed(underlying: SendableError(error))
         }
         return url
     }
@@ -175,7 +175,7 @@ public enum GeneratedImageError: Error, LocalizedError, Sendable {
     case photosAccessDenied
 
     /// The save operation failed.
-    case saveFailed(underlying: Error)
+    case saveFailed(underlying: SendableError)
 
     public var errorDescription: String? {
         switch self {

--- a/Tests/SwiftAITests/Core/GeneratedImageTests.swift
+++ b/Tests/SwiftAITests/Core/GeneratedImageTests.swift
@@ -329,7 +329,7 @@ final class GeneratedImageTests: XCTestCase {
 
     func testSaveFailedError() {
         let underlyingError = NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Test error"])
-        let error = GeneratedImageError.saveFailed(underlying: underlyingError)
+        let error = GeneratedImageError.saveFailed(underlying: SendableError(underlyingError))
 
         XCTAssertNotNil(error.errorDescription, "Error should have description")
         XCTAssertTrue(error.errorDescription?.contains("Failed to save") ?? false,


### PR DESCRIPTION
- Updated GeneratedImageError.saveFailed to use SendableError type
- Updated both save methods to wrap errors in SendableError
- Updated test to properly wrap NSError in SendableError

This ensures Swift 6 concurrency compliance.